### PR TITLE
upgrade releaser to go 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
- upgrade releaser to go 1.18